### PR TITLE
iOS AOT compilation fixes

### DIFF
--- a/tool/src/dotnet/Runtime.cs
+++ b/tool/src/dotnet/Runtime.cs
@@ -6,6 +6,10 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 
+#if __IOS__
+using ObjCRuntime;
+#endif
+
 namespace {{NAMESPACE}}.Diplomat;
 
 #nullable enable
@@ -103,11 +107,17 @@ public struct DiplomatWriteable : IDisposable
         }
     }
 
+#if __IOS__
+    [MonoPInvokeCallback(typeof(WriteableFlush))]
+#endif
     private static void Flush(IntPtr self)
     {
         // Nothing to do
     }
 
+#if __IOS__
+    [MonoPInvokeCallback(typeof(WriteableGrow))]
+#endif
     [return: MarshalAs(UnmanagedType.U1)]
     private unsafe static bool Grow(IntPtr writeable, nuint capacity)
     {


### PR DESCRIPTION
When calling C# delegate instances from unmanaged code, the runtime generates a trampoline that allows unmanaged code to call into managed code.

In Mono, the trampoline is generated by the JIT. However; iOS applications targeting a device cannot use JIT compilation (with some exceptions) and must be statically compiled (with some exceptions).

We must use the `MonoPInvokeCallback` to flag to the ahead-of-time compiler that a function will be called from unmanaged code, otherwise we will receive a runtime error.